### PR TITLE
Fix missing data resulting in missing rows (plus supporting no vars) …

### DIFF
--- a/src/main/java/org/veupathdb/service/eda/ss/model/Entity.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/model/Entity.java
@@ -112,9 +112,9 @@ public class Entity {
     return "id: " + getId() + " name: " + getDisplayName() + " (" + super.toString() + ")";
   }
   
-  public String getAllPksSelectList(String entityTableName, String ancestorTableName) {
+  public String getAllPksSelectList(String ancestorTableName) {
     List<String> selectColsList = new ArrayList<>();
-    selectColsList.add(entityTableName + "." + getPKColName());
+    selectColsList.add(ancestorTableName + "." + getPKColName());
     for (String name : getAncestorPkColNames())
       selectColsList.add(ancestorTableName + "." + name);
     return String.join(", ", selectColsList);

--- a/src/main/java/org/veupathdb/service/eda/ss/model/StudySubsettingUtils.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/model/StudySubsettingUtils.java
@@ -18,6 +18,7 @@ import static org.gusdb.fgputil.FormatUtil.TAB;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.gusdb.fgputil.ListBuilder;
 import org.gusdb.fgputil.Tuples.TwoTuple;
 import org.gusdb.fgputil.db.runner.SQLRunner;
 import org.gusdb.fgputil.db.runner.SingleIntResultSetHandler;
@@ -31,6 +32,9 @@ import org.veupathdb.service.eda.ss.model.Variable.VariableType;
 import org.veupathdb.service.eda.ss.model.filter.Filter;
 
 import static org.gusdb.fgputil.iterator.IteratorUtil.toIterable;
+import static org.veupathdb.service.eda.ss.model.RdbmsColumnNames.DATE_VALUE_COL_NAME;
+import static org.veupathdb.service.eda.ss.model.RdbmsColumnNames.NUMBER_VALUE_COL_NAME;
+import static org.veupathdb.service.eda.ss.model.RdbmsColumnNames.STRING_VALUE_COL_NAME;
 import static org.veupathdb.service.eda.ss.model.RdbmsColumnNames.TT_VARIABLE_ID_COL_NAME;
 
 /**
@@ -40,6 +44,8 @@ import static org.veupathdb.service.eda.ss.model.RdbmsColumnNames.TT_VARIABLE_ID
  *
  */
 public class StudySubsettingUtils {
+
+  private static final Logger LOG = LogManager.getLogger(StudySubsettingUtils.class);
 
   private static final int FETCH_SIZE_FOR_TABULAR_QUERIES = 2000;
 
@@ -63,6 +69,7 @@ public class StudySubsettingUtils {
     TreeNode<Entity> prunedEntityTree = pruneTree(study.getEntityTree(), filters, outputEntity);
 
     String sql = generateTabularSql(outputVariables, outputEntity, filters, prunedEntityTree);
+    LOG.info("Generated the following tabular SQL: " + sql);
 
     List<String> outputColumns = getTabularOutputColumns(outputEntity, outputVariables);
 
@@ -172,12 +179,31 @@ public class StudySubsettingUtils {
     String tallTblAbbrev = "t"; 
     String ancestorTblAbbrev = "a";
     
-    return generateWithClauses(prunedEntityTree, filters) + NL
-        + generateTabularSelectClause(outputEntity, tallTblAbbrev, ancestorTblAbbrev) + NL
-        + generateTabularFromClause(outputEntity, tallTblAbbrev, ancestorTblAbbrev) + NL
-        + generateTabularWhereClause(outputVariables, outputEntity.getPKColName(), tallTblAbbrev, ancestorTblAbbrev) + NL
-        + generateInClause(prunedEntityTree, outputEntity, tallTblAbbrev) + NL
+    return
+        // with clauses create an entity-named filtered result for each relevant entity
+        generateWithClauses(prunedEntityTree, filters) + NL +
+        // select
+        generateTabularSelectClause(outputEntity, ancestorTblAbbrev) + NL
+        + generateTabularFromClause(outputEntity, prunedEntityTree, ancestorTblAbbrev) + NL
+        + generateLeftJoin(outputEntity, outputVariables, ancestorTblAbbrev, tallTblAbbrev) + NL
         + generateTabularOrderByClause(outputEntity) + NL;
+  }
+
+  private static String generateLeftJoin(Entity outputEntity, List<Variable> outputVariables, String ancestorTblAbbrev, String tallTblAbbrev) {
+    if (outputVariables.isEmpty()) {
+      return " LEFT JOIN ( SELECT " +
+          "null as " + TT_VARIABLE_ID_COL_NAME + ", "  +
+          "null as " + STRING_VALUE_COL_NAME + ", " +
+          "null as " + DATE_VALUE_COL_NAME + ", " +
+          "null as " + NUMBER_VALUE_COL_NAME +
+        " FROM DUAL ) ON 1 = 1 ";
+    }
+    String pkColName = outputEntity.getPKColName();
+    return " LEFT JOIN (" + NL
+        + " SELECT * FROM " + Resources.getAppDbSchema() + outputEntity.getTallTableName() + " " + NL
+        + generateTabularWhereClause(outputVariables, pkColName) + NL
+        + " ) " + tallTblAbbrev + NL
+        + " ON " + ancestorTblAbbrev + "." + pkColName + " = " + tallTblAbbrev + "." + pkColName;
   }
 
   /*
@@ -188,7 +214,7 @@ public class StudySubsettingUtils {
     return generateWithClauses(prunedEntityTree, filters) + NL
         + "SELECT count(distinct " + outputEntity.getPKColName() + ") as " + COUNT_COLUMN_NAME + NL
         + "FROM (" + NL
-        + generateJoiningSubselect(prunedEntityTree, outputEntity) + NL
+        + generateJoiningSubselect(prunedEntityTree, outputEntity, false) + NL
         + ") t";
   }
   
@@ -196,7 +222,6 @@ public class StudySubsettingUtils {
    * Generate SQL to produce a distribution for a single variable, for the specified subset.
    */
   static String generateDistributionSql(Entity outputEntity, Variable distributionVariable, List<Filter> filters, TreeNode<Entity> prunedEntityTree) {
-    
     return generateWithClauses(prunedEntityTree, filters) + NL
         + generateDistributionSelectClause(distributionVariable) + NL
         + generateDistributionFromClause(outputEntity) + NL
@@ -210,7 +235,6 @@ public class StudySubsettingUtils {
    * Generate SQL to produce a count of the entities that have a value for a variable, for the specified subset.
    */
   static String generateVariableCountSql(Entity outputEntity, Variable variable, List<Filter> filters, TreeNode<Entity> prunedEntityTree) {
-    
     return generateWithClauses(prunedEntityTree, filters) + NL
         + generateVariableCountSelectClause(variable) + NL
         + generateDistributionFromClause(outputEntity) + NL
@@ -234,10 +258,10 @@ public class StudySubsettingUtils {
     List<String> selectColsList = new ArrayList<>(entity.getAncestorPkColNames());
     selectColsList.add(entity.getPKColName());
     String selectCols = String.join(", ", selectColsList);
-    
+
     // default WITH body assumes no filters. we use the ancestor table because it is small
     String withBody = "  SELECT " + selectCols + " FROM " + Resources.getAppDbSchema() + entity.getAncestorsTableName() + NL;
-    
+
     List<Filter> filtersOnThisEntity = filters.stream().filter(f -> f.getEntity().getId().equals(entity.getId())).collect(Collectors.toList());
 
     if (!filtersOnThisEntity.isEmpty()) {
@@ -248,13 +272,13 @@ public class StudySubsettingUtils {
     return entity.getWithClauseName() + " as (" + NL + withBody + ")";
   }
   
-  static String generateTabularSelectClause(Entity outputEntity, String tallTblAbbrev, String ancestorTblAbbrev) {
-    Set<String> valColNames = new HashSet<>();
-    for (VariableType varType : VariableType.values()) valColNames.add(varType.getTallTableColumnName());
-
-    return "SELECT " + outputEntity.getAllPksSelectList(tallTblAbbrev, ancestorTblAbbrev) + ", " + 
-    TT_VARIABLE_ID_COL_NAME + ", " +
-    String.join(", ", valColNames);
+  static String generateTabularSelectClause(Entity outputEntity, String ancestorTblAbbrev) {
+    Set<String> valColNames = Arrays
+        .stream(VariableType.values())
+        .map(VariableType::getTallTableColumnName)
+        .collect(Collectors.toSet());
+    return "SELECT " + outputEntity.getAllPksSelectList(ancestorTblAbbrev) + ", " +
+        TT_VARIABLE_ID_COL_NAME + ", " + String.join(", ", valColNames);
   }
     
   static String generateDistributionSelectClause(Variable distributionVariable) {
@@ -269,20 +293,20 @@ public class StudySubsettingUtils {
   static String generateDistributionFromClause(Entity outputEntity) {
     return "FROM " + Resources.getAppDbSchema() + outputEntity.getTallTableName();
   }
-  
-  static String generateTabularFromClause(Entity outputEntity, String entityTblNm, String ancestorTblNm) {
-    return "FROM " + Resources.getAppDbSchema() + outputEntity.getTallTableName() + " " + entityTblNm + ", " +
-        Resources.getAppDbSchema() + outputEntity.getAncestorsTableName() + " " + ancestorTblNm;
-  }
-  
-  static String generateTabularWhereClause(List<Variable> outputVariables, String entityPkCol, String entityTblNm, String ancestorTblNm) {
-    
-    List<String> outputVariableIds = outputVariables.stream().map(Variable::getId).collect(Collectors.toList());
 
-    List<String> varExprs = new ArrayList<>();
-    for (String varId : outputVariableIds) varExprs.add(" " + TT_VARIABLE_ID_COL_NAME + " = '" + varId + "'");
-    return "WHERE " + entityTblNm + "." + entityPkCol + " = " + ancestorTblNm + "." + entityPkCol + NL + (
-        varExprs.isEmpty() ? "" : "AND (" + NL + String.join(" OR" + NL, varExprs) + NL + ")" + NL);
+  private static String generateTabularFromClause(Entity outputEntity, TreeNode<Entity> prunedEntityTree, String ancestorTblAbbrev) {
+    return " FROM ( " + generateJoiningSubselect(prunedEntityTree, outputEntity, true) + " ) " + ancestorTblAbbrev;
+  }
+
+  static String generateTabularWhereClause(List<Variable> outputVariables, String entityPkCol) {
+    
+    List<String> outputVariableExprs = outputVariables.stream()
+        .map(Variable::getId)
+        .map(varId -> " " + TT_VARIABLE_ID_COL_NAME + " = '" + varId + "'")
+        .collect(Collectors.toList());
+
+    return outputVariableExprs.isEmpty() ? "" :
+        " WHERE (" + NL + String.join(" OR" + NL, outputVariableExprs) + NL + ")" + NL;
   }
   
   static String generateDistributionWhereClause(Variable outputVariable) {
@@ -291,18 +315,22 @@ public class StudySubsettingUtils {
 
   static String generateInClause(TreeNode<Entity> prunedEntityTree, Entity outputEntity, String tallTblAbbrev) {
     return "AND" + " " + tallTblAbbrev + "." + outputEntity.getPKColName() + " IN (" + NL
-    + generateJoiningSubselect(prunedEntityTree, outputEntity) + NL
+    + generateJoiningSubselect(prunedEntityTree, outputEntity, false) + NL
     + ")";
   }
   
-  static String generateJoiningSubselect(TreeNode<Entity> prunedEntityTree, Entity outputEntity) {
-    return generateJoiningSelectClause(outputEntity) + NL
+  static String generateJoiningSubselect(TreeNode<Entity> prunedEntityTree, Entity outputEntity, boolean returnAncestorIds) {
+    return generateJoiningSelectClause(outputEntity, returnAncestorIds) + NL
     + generateJoiningFromClause(prunedEntityTree) + NL
     + generateJoiningJoinsClause(prunedEntityTree); 
   }
   
-  static String generateJoiningSelectClause(Entity outputEntity) {
-    return "  SELECT " + outputEntity.getFullPKColName();
+  static String generateJoiningSelectClause(Entity outputEntity, boolean returnAncestorIds) {
+    List<String> returnedCols = ListBuilder.asList(outputEntity.getFullPKColName());
+    if (returnAncestorIds) {
+      returnedCols.addAll(outputEntity.getAncestorPkColNames());
+    }
+    return "  SELECT " + returnedCols.stream().collect(Collectors.joining(", "));
   }
   
   static String generateJoiningFromClause(TreeNode<Entity> prunedEntityTree) {

--- a/src/main/java/org/veupathdb/service/eda/ss/model/filter/Filter.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/model/filter/Filter.java
@@ -25,7 +25,7 @@ public abstract class Filter {
 
   private String getSqlWithAncestors() {
 
-    return "  SELECT " + entity.getAllPksSelectList("t", "a") + NL
+    return "  SELECT " + entity.getAllPksSelectList("a") + NL
         + "  FROM " + Resources.getAppDbSchema() + entity.getTallTableName() + " t, " + Resources.getAppDbSchema() + entity.getAncestorsTableName() + " a" + NL
         + "  WHERE t." + entity.getPKColName() + " = a." + entity.getPKColName() + NL
         + "  AND " + TT_VARIABLE_ID_COL_NAME + " = '" + variableId + "'" + NL

--- a/src/main/resources/org/veupathdb/service/eda/ss/stubdb/createDbSchema.sql
+++ b/src/main/resources/org/veupathdb/service/eda/ss/stubdb/createDbSchema.sql
@@ -1,3 +1,7 @@
+
+-- use oracle syntax throughout execution
+SET DATABASE SQL SYNTAX ORA TRUE;
+
 -- the EDA service doesn't need to know much about the Study, because the WDK will serve that data
 -- the abbrev would be used in the name of the tall and ancestors tables
 -- the study_id is a stable ID

--- a/src/main/resources/org/veupathdb/service/eda/ss/stubdb/insertDbData.sql
+++ b/src/main/resources/org/veupathdb/service/eda/ss/stubdb/insertDbData.sql
@@ -49,26 +49,31 @@ insert into AttributeGraph_ds2324_Prtcpnt values ('var_10', 300, null, '_networt
 insert into AttributeGraph_ds2324_Prtcpnt values ('var_11', 300, null, '_shoesize', 'Shoe size', 'default', 1, 'number', 0, 'categorical', 'size', null, 1);
 insert into AttributeGraph_ds2324_Prtcpnt values ('var_20', 200, null, '_name', 'Name', 'default', 1, 'string', 0, 'categorical', null, null, null);
 insert into AttributeGraph_ds2324_Prtcpnt values ('var_17', 200, null, '_haircolor', 'Hair color', 'default', 1, 'string', 0,  'categorical', null, null, null);
+insert into AttributeGraph_ds2324_Prtcpnt values ('var_18', 200, null, '_earsize', 'Ear size', 'default', 1, 'string', 0,  'categorical', null, null, null);
 
 insert into Ancestors_ds2324_Prtcpnt values ('201', '101');
 insert into AttributeValue_ds2324_Prtcpnt values ('201', 'var_20', null, 'Martin', null);
 insert into AttributeValue_ds2324_Prtcpnt values ('201', 'var_11', 11.5, null, null);
 insert into AttributeValue_ds2324_Prtcpnt values ('201', 'var_17', null, 'blond', null);
+insert into AttributeValue_ds2324_Prtcpnt values ('201', 'var_18', null, 'small', null);
 
 insert into Ancestors_ds2324_Prtcpnt values ('202', '101');
 insert into AttributeValue_ds2324_Prtcpnt values ('202', 'var_20', null, 'Abe', null);
 insert into AttributeValue_ds2324_Prtcpnt values ('202', 'var_11', 10, null, null);
 insert into AttributeValue_ds2324_Prtcpnt values ('202', 'var_17', null, 'blond', null);
+insert into AttributeValue_ds2324_Prtcpnt values ('202', 'var_18', null, 'medium', null);
 
 insert into Ancestors_ds2324_Prtcpnt values ('203', '102');
 insert into AttributeValue_ds2324_Prtcpnt values ('203', 'var_20', null, 'Gladys', null);
 insert into AttributeValue_ds2324_Prtcpnt values ('203', 'var_11', 11.5, null, null);
 insert into AttributeValue_ds2324_Prtcpnt values ('203', 'var_17', null, 'brown', null);
+insert into AttributeValue_ds2324_Prtcpnt values ('203', 'var_18', null, 'large', null);
 
 insert into Ancestors_ds2324_Prtcpnt values ('204', '102');
 insert into AttributeValue_ds2324_Prtcpnt values ('204', 'var_20', null, 'Susan', null);
 insert into AttributeValue_ds2324_Prtcpnt values ('204', 'var_11', 10, null, null);
 insert into AttributeValue_ds2324_Prtcpnt values ('204', 'var_17', null, 'silver', null);
+-- intentionally omit var_18 to test left join logic
 
 -- participant observations
 

--- a/src/test/java/org/veupathdb/service/eda/ss/model/LoadStudyTest.java
+++ b/src/test/java/org/veupathdb/service/eda/ss/model/LoadStudyTest.java
@@ -109,7 +109,7 @@ public class LoadStudyTest {
 
     List<Variable> variables = VariableResultSetUtils.getEntityVariables(datasource, entity);
     
-    assertEquals(4, variables.size());
+    assertEquals(5, variables.size());
   }
   
   @Test

--- a/src/test/java/org/veupathdb/service/eda/ss/model/StudySubsettingUtilsTest.java
+++ b/src/test/java/org/veupathdb/service/eda/ss/model/StudySubsettingUtilsTest.java
@@ -1,6 +1,11 @@
 package org.veupathdb.service.eda.ss.model;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.gusdb.fgputil.DelimitedDataParser;
+import org.gusdb.fgputil.FormatUtil;
 import org.gusdb.fgputil.Tuples.TwoTuple;
+import org.gusdb.fgputil.db.runner.SQLRunner;
 import org.gusdb.fgputil.functional.Functions;
 import org.gusdb.fgputil.functional.TreeNode;
 import org.gusdb.fgputil.iterator.IteratorUtil;
@@ -16,10 +21,13 @@ import java.util.*;
 import java.util.stream.Stream;
 
 import static org.gusdb.fgputil.FormatUtil.NL;
+import static org.gusdb.fgputil.FormatUtil.TAB;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.veupathdb.service.eda.ss.model.RdbmsColumnNames.*;
 
 public class StudySubsettingUtilsTest {
+
+  private static final Logger LOG = LogManager.getLogger(StudySubsettingUtilsTest.class);
 
   private static TestModel _model;
   private static DataSource _dataSource;
@@ -165,7 +173,7 @@ public class StudySubsettingUtilsTest {
     String withClause = StudySubsettingUtils.generateWithClause(_model.observation, filters);
  
     List<String> selectColsList = new ArrayList<>();
-    selectColsList.add("t." + _model.observation.getPKColName());
+    selectColsList.add("a." + _model.observation.getPKColName());
     for (String name : _model.observation.getAncestorPkColNames()) selectColsList.add("a." + name);
     String selectCols = String.join(", ", selectColsList);
 
@@ -205,8 +213,8 @@ public class StudySubsettingUtilsTest {
   @DisplayName("Test creating a select clause for tabular report")
   void testGenerateTabularSelectClause() {
     
-    String selectClause = StudySubsettingUtils.generateTabularSelectClause(_model.observation, "t", "a");
-    String expectedSelectClause = "SELECT t." + _model.observation.getPKColName() +
+    String selectClause = StudySubsettingUtils.generateTabularSelectClause(_model.observation, "a");
+    String expectedSelectClause = "SELECT a." + _model.observation.getPKColName() +
         ", a." + _model.participant.getPKColName() +
         ", a." + _model.household.getPKColName() +
         ", " + TT_VARIABLE_ID_COL_NAME + ", " + STRING_VALUE_COL_NAME + ", " + NUMBER_VALUE_COL_NAME + ", " + DATE_VALUE_COL_NAME;
@@ -260,9 +268,8 @@ public class StudySubsettingUtilsTest {
   void testGenerateTabularWhereClause() {
     
     List<Variable> vars = Arrays.asList(_model.birthDate, _model.favNumber);
-    String where = StudySubsettingUtils.generateTabularWhereClause(vars, _model.observation.getPKColName(), "t", "a");
-    String expected = "WHERE t." + _model.observation.getPKColName() + " = a." + _model.observation.getPKColName() + NL +
-        "AND (" + NL +
+    String where = StudySubsettingUtils.generateTabularWhereClause(vars, _model.observation.getPKColName());
+    String expected = " WHERE (" + NL +
         " " + TT_VARIABLE_ID_COL_NAME + " = '" + _model.birthDate.getId() + "' OR" + NL +
         " " + TT_VARIABLE_ID_COL_NAME + " = '" + _model.favNumber.getId() + "'" + NL +
         ")" + NL;
@@ -557,4 +564,65 @@ public class StudySubsettingUtilsTest {
     return filters;
   }
 
+  @Test
+  @DisplayName("Test tabular results without vars containing no nulls")
+  void testTabularResultsNoVars() {
+    testTabularResults(Arrays.asList());
+  }
+
+  @Test
+  @DisplayName("Test tabular results with vars containing data for all rows")
+  void testTabularResultsVarsWithData() {
+    testTabularResults(Arrays.asList(_model.haircolor, _model.shoesize));
+  }
+
+  @Test
+  @DisplayName("Test tabular results with vars containing missing data for one var")
+  void testTabularResultsVarsWithMissingData() {
+    testTabularResults(Arrays.asList(_model.networth, _model.shoesize));
+  }
+
+  @Test
+  @DisplayName("Test tabular results with vars containing missing data for some rows")
+  void testTabularResultsVarsWithPartialData() {
+    testTabularResults(Arrays.asList(_model.earsize, _model.shoesize));
+  }
+  private void testTabularResults(List<Variable> requestedVars) {
+    Entity entity = _model.participant;
+    List<Map<String,String>> results = getTabularOutputRows(entity, requestedVars);
+
+    for (Map<String,String> row : results) {
+      LOG.info(FormatUtil.prettyPrint(row, FormatUtil.Style.SINGLE_LINE));
+    }
+    // test number of results; should always be the same regardless of var data (PKs always provided)
+    assertEquals(4, results.size());
+
+    Map<String,String> firstRow = results.iterator().next();
+
+    // make sure results have cols for entity PK and ancestor PKs
+    assertTrue(firstRow.containsKey(entity.getPKColName()));
+    for (String ancestorPk : entity.getAncestorPkColNames()) {
+      assertTrue(firstRow.containsKey(ancestorPk));
+    }
+
+    // make sure results have cols for all requested rows
+    for (Variable var : requestedVars) {
+      assertTrue(firstRow.containsKey(var.getId()));
+    }
+  }
+
+  private List<Map<String,String>> getTabularOutputRows(Entity entity, List<Variable> requestedVars) {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    StudySubsettingUtils.produceTabularSubset(_dataSource, _model.study, entity, requestedVars, Collections.emptyList(), buffer);
+    Scanner scanner = new Scanner(buffer.toString());
+    if (!scanner.hasNextLine()) {
+      throw new RuntimeException("Tabular output did not contain a header row.");
+    }
+    DelimitedDataParser parser = new DelimitedDataParser(scanner.nextLine(), TAB, true);
+    List<Map<String,String>> rows = new ArrayList<>();
+    while(scanner.hasNextLine()) {
+      rows.add(parser.parseLine(scanner.nextLine()));
+    }
+    return rows;
+  }
 }

--- a/src/test/java/org/veupathdb/service/eda/ss/model/TestModel.java
+++ b/src/test/java/org/veupathdb/service/eda/ss/model/TestModel.java
@@ -44,6 +44,7 @@ public class TestModel {
   public Variable mood;
   public Variable haircolor;
   public Variable networth;
+  public Variable earsize;
   public Variable waterSupply;
   
   public Filter obsWeightFilter;
@@ -56,19 +57,19 @@ public class TestModel {
   
   public TestModel() {
     createTestEntities();
-    Study.StudyOverview overview = new Study.StudyOverview("GEMS", "datasetid_2222", "555555");
+    Study.StudyOverview overview = new Study.StudyOverview("GEMS", "datasetid_2222", "ds2324");
     study = new Study(overview, constructEntityTree(), createIdMap());
     constructVariables();
     createFilters();
   }
   
   private void createTestEntities() {
-    household = new Entity("GEMS_House", "555555", "Household", "Households", "descrip", "Hshld");
-    householdObs = new Entity("GEMS_HouseObs", "555555", "Household Observation", "Household Observations", "descrip", "HshldObsvtn");
-    participant = new Entity("GEMS_Part", "555555", "Participant", "Participants", "descrip", "Prtcpnt");
-    observation = new Entity("GEMS_PartObs", "555555", "Observation", "Observations", "descrip", "PrtcpntObsrvtn");
-    sample = new Entity("GEMS_Sample", "555555", "Sample", "Samples", "descrip", "Smpl");
-    treatment = new Entity("GEMS_Treat", "555555", "Treatment", "Treatments", "descrip", "Trtmnt");
+    household = new Entity("GEMS_House", "ds2324", "Household", "Households", "descrip", "Hshld");
+    householdObs = new Entity("GEMS_HouseObs", "ds2324", "Household Observation", "Household Observations", "descrip", "HshldObsvtn");
+    participant = new Entity("GEMS_Part", "ds2324", "Participant", "Participants", "descrip", "Prtcpnt");
+    observation = new Entity("GEMS_PartObs", "ds2324", "Observation", "Observations", "descrip", "PrtcpntObsrvtn");
+    sample = new Entity("GEMS_Sample", "ds2324", "Sample", "Samples", "descrip", "Smpl");
+    treatment = new Entity("GEMS_Treat", "ds2324", "Treatment", "Treatments", "descrip", "Trtmnt");
   }
   
   private Map<String, Entity> createIdMap() {
@@ -122,9 +123,13 @@ public class TestModel {
             Variable.VariableDisplayType.DEFAULT, "", 1, "Roof", null);
     participant.addVariable(haircolor);
 
-    networth = new Variable("networth", "var_18", participant, VariableType.NUMBER, VariableDataShape.CONTINUOUS,
+    networth = new Variable("networth", "var_10", participant, VariableType.NUMBER, VariableDataShape.CONTINUOUS,
             Variable.VariableDisplayType.DEFAULT, "", 1, "Roof", null);
     participant.addVariable(networth);
+
+    earsize = new Variable("earsize", "var_18", participant, VariableType.STRING, VariableDataShape.CATEGORICAL,
+            Variable.VariableDisplayType.DEFAULT, "", 1, "Roof", null);
+    participant.addVariable(earsize);
 
     weight = new Variable("weight", "var_12", observation, VariableType.NUMBER, Variable.VariableDataShape.CONTINUOUS,
             Variable.VariableDisplayType.DEFAULT, "", 1, "Roof", null);


### PR DESCRIPTION
The primary fix in this PR is a refactor of the tabular endpoint's SQL to use a left join to ensure that at least one row for every record in the requested subset is returned by the tall tables.  These new "null rows" are handled by the Java code, filling in empty strings in the tab delimited output for vars that have no data, even if no requested vars have data (IDs are still provided).

Another longstanding request to allow zero vars to be requested (output still gets one tabular row per subset record) is also fixed in this PR.  Unit tests confirm that with various amounts of filled in data, and with zero or more vars requested, we always return the same number of rows.