### PR TITLE
Variable checks for null values (and no longer provide default if wrong format)

### DIFF
--- a/src/main/java/org/veupathdb/service/eda/ss/model/EntityResultSetUtils.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/model/EntityResultSetUtils.java
@@ -20,25 +20,25 @@ import org.veupathdb.service.eda.ss.model.variable.VariableWithValues;
 
 import static org.gusdb.fgputil.FormatUtil.NL;
 import static org.veupathdb.service.eda.ss.model.RdbmsColumnNames.*;
-import static org.veupathdb.service.eda.ss.model.ResultSetUtils.getRsStringNotNull;
+import static org.veupathdb.service.eda.ss.model.ResultSetUtils.getRsString;
 import static org.veupathdb.service.eda.ss.model.ResultSetUtils.getRsStringWithDefault;
 
 /**
  * utilities for creating Entities from result sets
- * @author Steve
  *
+ * @author Steve
  */
 public class EntityResultSetUtils {
 
   private final static String STDY_ABBRV_COL_NM = "study_abbrev"; // for private queries
 
   static TreeNode<Entity> getStudyEntityTree(DataSource datasource, String studyId) {
-    
+
     String sql = generateEntityTreeSql(studyId);
-    
+
     // entityID -> list of child entities
     Map<String, List<Entity>> simpleTree = new HashMap<>();
-    
+
     Entity rootEntity = new SQLRunner(datasource, sql, "Get entity tree").executeQuery(rs -> {
       Entity root = null;
       while (rs.next()) {
@@ -47,14 +47,15 @@ public class EntityResultSetUtils {
         if (parentId == null) {
           if (root != null) throw new RuntimeException("In Study " + studyId + " found more than one root entity");
           root = entity;
-        } else {
+        }
+        else {
           if (!simpleTree.containsKey(parentId)) simpleTree.put(parentId, new ArrayList<>());
           simpleTree.get(parentId).add(entity);
         }
       }
       return root;
     });
-    
+
     if (rootEntity == null) throw new RuntimeException("Found no entities for study: " + studyId);
 
     List<Entity> rootKids = simpleTree.get(rootEntity.getId());
@@ -62,37 +63,37 @@ public class EntityResultSetUtils {
     populateEntityTree(rootNode, rootKids, simpleTree);
     return rootNode;
   }
-  
+
   static void populateEntityTree(TreeNode<Entity> parentNode, List<Entity> children, Map<String, List<Entity>> simpleTree) {
     for (Entity child : children) {
       TreeNode<Entity> childNode = new TreeNode<>(child);
       parentNode.addChildNode(childNode);
-      
+
       // if this node has children, recurse
       if (simpleTree.containsKey(child.getId()))
         populateEntityTree(childNode, simpleTree.get(child.getId()), simpleTree);
     }
   }
-  
+
   static String generateEntityTreeSql(String studyId) {
-    String[] entityCols = {STUDY_ID_COL_NAME, ENTITY_ABBREV_COL_NAME, DISPLAY_NAME_COL_NAME, DISPLAY_NAME_PLURAL_COL_NAME, ENTITY_ID_COL_NAME, DESCRIP_COL_NAME, ENTITY_PARENT_ID_COL_NAME};
+    String[] entityCols = { STUDY_ID_COL_NAME, ENTITY_ABBREV_COL_NAME, DISPLAY_NAME_COL_NAME, DISPLAY_NAME_PLURAL_COL_NAME, ENTITY_ID_COL_NAME, DESCRIP_COL_NAME, ENTITY_PARENT_ID_COL_NAME };
     return "SELECT e." + String.join(", e.", entityCols) + ", s." + STUDY_ABBREV_COL_NAME + " as " + STDY_ABBRV_COL_NM + NL
         + "FROM " + Resources.getAppDbSchema() + ENTITY_TABLE_NAME + " e," + Resources.getAppDbSchema() + STUDY_TABLE_NAME + " s " + NL
         + "WHERE s." + STUDY_ID_COL_NAME + " = '" + studyId + "'" + NL
-        + "AND e." + ENTITY_STUDY_ID_COL_NAME + " = s." + STUDY_ID_COL_NAME  + NL
+        + "AND e." + ENTITY_STUDY_ID_COL_NAME + " = s." + STUDY_ID_COL_NAME + NL
         + "ORDER BY e." + ENTITY_ID_COL_NAME;  // stable ordering supports unit testing
   }
 
   static Entity createEntityFromResultSet(ResultSet rs) {
 
     try {
-      String name = getRsStringNotNull(rs, DISPLAY_NAME_COL_NAME);
+      String name = getRsString(rs, DISPLAY_NAME_COL_NAME, true);
       String namePlural = rs.getString(DISPLAY_NAME_PLURAL_COL_NAME);
       if (namePlural == null) namePlural = name + "s";  // TODO remove this hack when db has plurals
-      String id = getRsStringNotNull(rs, ENTITY_ID_COL_NAME);
-      String studyAbbrev = getRsStringNotNull(rs, STDY_ABBRV_COL_NM);
+      String id = getRsString(rs, ENTITY_ID_COL_NAME, true);
+      String studyAbbrev = getRsString(rs, STDY_ABBRV_COL_NM, true);
       String descrip = getRsStringWithDefault(rs, DESCRIP_COL_NAME, "No Entity Description available");
-      String abbrev = getRsStringNotNull(rs, ENTITY_ABBREV_COL_NAME);
+      String abbrev = getRsString(rs, ENTITY_ABBREV_COL_NAME, true);
 
       return new Entity(id, studyAbbrev, name, namePlural, descrip, abbrev);
     }
@@ -100,10 +101,10 @@ public class EntityResultSetUtils {
       throw new RuntimeException(e);
     }
   }
-  
+
   /**
    * Tall table rows look like this:
-   *   ancestor1_pk, ancestor2_pk, pk, variableA_id, string_value, number_value, date_value
+   * ancestor1_pk, ancestor2_pk, pk, variableA_id, string_value, number_value, date_value
    */
   static Map<String, String> resultSetToTallRowMap(Entity entity, ResultSet rs) {
 
@@ -123,9 +124,9 @@ public class EntityResultSetUtils {
       // add variable value to map (skip if ID is null)
       if (variableId != null) {
         VariableWithValues var = entity.getVariable(variableId)
-          .map(v -> (VariableWithValues)v)
-          .orElseThrow(() -> new RuntimeException(
-              "Metadata does not have variable found in tall table result set: " + variableId));
+            .map(v -> (VariableWithValues)v)
+            .orElseThrow(() -> new RuntimeException(
+                "Metadata does not have variable found in tall table result set: " + variableId));
 
         tallRow.put(VARIABLE_VALUE_COL_NAME, var.getType().convertRowValueToStringValue(rs));
       }
@@ -135,51 +136,51 @@ public class EntityResultSetUtils {
       throw new RuntimeException(e);
     }
   }
+
   /**
    * Return a function that transforms a list of tall table rows for a given entity ID to a single wide row.
-   * 
+   * <p>
    * Tall table rows look like this:
-   *   ancestor1_pk, ancestor2_pk, pk, variableA_id, value
-   *   ancestor1_pk, ancestor2_pk, pk, variableB_id, value
-   *   ancestor1_pk, ancestor2_pk, pk, variableC_id, value
-   *   
-   *   (ordered by the ancestry IDs and then the variable ID)
-   *   
+   * ancestor1_pk, ancestor2_pk, pk, variableA_id, value
+   * ancestor1_pk, ancestor2_pk, pk, variableB_id, value
+   * ancestor1_pk, ancestor2_pk, pk, variableC_id, value
+   * <p>
+   * (ordered by the ancestry IDs and then the variable ID)
+   * <p>
    * Output wide row looks like this:
-   *   ancestor1_pk, ancestor2_pk, pk, variableA_value, variableB_value, variableC_value
-   *   
-   *   (all values are converted to strings)
+   * ancestor1_pk, ancestor2_pk, pk, variableA_value, variableB_value, variableC_value
+   * <p>
+   * (all values are converted to strings)
    */
   static Function<List<Map<String, String>>, Map<String, String>> getTallToWideFunction(Entity entity) {
-    
+
     String errPrefix = "Tall row supplied to entity " + entity.getId();
 
     return tallRows -> {
 
-      Map<String,String> firstTallRow = tallRows.get(0);
+      Map<String, String> firstTallRow = tallRows.get(0);
       Map<String, String> wideRow = new HashMap<>();
       String tallRowEntityId = firstTallRow.get(entity.getPKColName());
       Map<String, List<String>> multiValues = null;  // this map only contains variables that have multiple values
       Map<String, VariableWithValues> variablesMap = new HashMap<>(); // ID -> VariableWithValues
-      
+
       addPrimaryKeysToWideRow(firstTallRow, entity, wideRow, tallRowEntityId, errPrefix);
 
       // loop through all tall rows and add vars to wide row, validating along the way
       // temporarily store any multi-values in a dedicated map.  (at the end, reduce them to JSON string)
       for (Map<String, String> tallRow : tallRows) {
         String variableId = tallRow.get(TT_VARIABLE_ID_COL_NAME);
-        if (variableId == null) continue;
-        else {
-          
+        if (variableId != null) {
+
           // validate row, and add this var to variablesMap if not already there
           validateTallRow(entity, tallRow, errPrefix, tallRowEntityId, variableId, variablesMap);
-          
+
           // handle multi valued variable.
           // (this is a rare case, so only allocate the array if needed)
           if (variablesMap.get(variableId).getIsMultiValued()) {
             multiValues = updateMultiValuesMap(variableId, tallRow, multiValues);
           }
-          
+
           // else handle single valued variable
           else {
             if (wideRow.containsKey(variableId)) throw new RuntimeException("Variable found to incorrectly have multiple values: " + variableId);
@@ -187,18 +188,18 @@ public class EntityResultSetUtils {
           }
         }
       }
-      
+
       // reduce multi-values to JSON string, and stuff into wide row
-      if (multiValues != null) putMultiValuesAsJsonIntoWideRow(multiValues, wideRow, entity, variablesMap);
-      
+      if (multiValues != null) putMultiValuesAsJsonIntoWideRow(multiValues, wideRow, variablesMap);
+
       return wideRow;
     };
   }
 
-  private static void addPrimaryKeysToWideRow(Map<String,String> firstTallRow, 
-      Entity entity, Map<String, String> wideRow, String tallRowEntityId, String errPrefix) {
+  private static void addPrimaryKeysToWideRow(Map<String, String> firstTallRow,
+                                              Entity entity, Map<String, String> wideRow, String tallRowEntityId, String errPrefix) {
     // add entity PK to the wide row
-     wideRow.put(entity.getPKColName(), tallRowEntityId);
+    wideRow.put(entity.getPKColName(), tallRowEntityId);
 
     // add ancestor PKs to wide row
     for (String ancestorPkColName : entity.getAncestorPkColNames()) {
@@ -207,16 +208,16 @@ public class EntityResultSetUtils {
       wideRow.put(ancestorPkColName, firstTallRow.get(ancestorPkColName));
     }
   }
-  
+
   // update provided map (side-effect) with a new multi-value for the given variable ID.
   // if map passed in is null, create new map
   private static Map<String, List<String>> updateMultiValuesMap(String variableId, Map<String, String> tallRow, Map<String, List<String>> multiValuesMap) {
 
     // if this is our first multi-valued guy, create the empty map
-    if (multiValuesMap == null)  multiValuesMap = new HashMap<String, List<String>>();
+    if (multiValuesMap == null) multiValuesMap = new HashMap<>();
 
     String tallRowValue = tallRow.get(VARIABLE_VALUE_COL_NAME);
-	  
+
     // we either get a single tall row with a null, if the data is missing for this entity
     // or one or more rows with values.
     if (tallRowValue == null) {
@@ -224,36 +225,37 @@ public class EntityResultSetUtils {
       multiValuesMap.put(variableId, null);
     }
     else {
-      if (!multiValuesMap.containsKey(variableId)) multiValuesMap.put(variableId, new ArrayList<String>());
+      if (!multiValuesMap.containsKey(variableId)) multiValuesMap.put(variableId, new ArrayList<>());
       multiValuesMap.get(variableId).add(tallRowValue);
     }
-	  return multiValuesMap;
+    return multiValuesMap;
   }
-  
+
   // for those variables that have multi-values, transform the list of string values to 
   // appropriate json array, and put that array into the wide row
-	protected static void putMultiValuesAsJsonIntoWideRow(Map<String, List<String>> multiValues,
-			Map<String, String> wideRow, Entity entity, Map<String, VariableWithValues> variablesMap) {
-	  
-		for (String multiValVarId : multiValues.keySet()) {
-			VariableWithValues vwv = variablesMap.get(multiValVarId);
-			JSONArray jsonArray = vwv.getType().convertStringListToJsonArray(multiValues.get(multiValVarId));
-			wideRow.put(multiValVarId, jsonArray.toString());
-		}
-	}
-  
-  private static void validateTallRow(Entity entity, Map<String,String> tallRow, String errPrefix, 
-      String tallRowEnityId, String variableId, Map<String, VariableWithValues> variablesMap) {
+  protected static void putMultiValuesAsJsonIntoWideRow(Map<String, List<String>> multiValues,
+                                                        Map<String, String> wideRow,
+                                                        Map<String, VariableWithValues> variablesMap) {
+
+    for (String multiValVarId : multiValues.keySet()) {
+      VariableWithValues vwv = variablesMap.get(multiValVarId);
+      JSONArray jsonArray = vwv.getType().convertStringListToJsonArray(multiValues.get(multiValVarId));
+      wideRow.put(multiValVarId, jsonArray.toString());
+    }
+  }
+
+  private static void validateTallRow(Entity entity, Map<String, String> tallRow, String errPrefix,
+                                      String tallRowEnityId, String variableId, Map<String, VariableWithValues> variablesMap) {
     // do some simple validation
-    if (tallRow.size() != entity.getTallRowSize()) 
+    if (tallRow.size() != entity.getTallRowSize())
       throw new RuntimeException(errPrefix + " has an unexpected number of columns: (" + tallRow.size() + "): " + tallRow.keySet());
-    
+
     if (!tallRow.get(entity.getPKColName()).equals(tallRowEnityId))
       throw new RuntimeException(errPrefix + " has an unexpected PK value");
 
-    if (!tallRow.containsKey(TT_VARIABLE_ID_COL_NAME) )
+    if (!tallRow.containsKey(TT_VARIABLE_ID_COL_NAME))
       throw new RuntimeException(errPrefix + " does not contain column " + TT_VARIABLE_ID_COL_NAME);
-    
+
     if (!variablesMap.containsKey(variableId)) {
       Variable var = entity.getVariable(variableId)
           .orElseThrow(() -> new RuntimeException(errPrefix + " has an invalid variableId: " + variableId));
@@ -261,8 +263,8 @@ public class EntityResultSetUtils {
       if (!(var instanceof VariableWithValues))
         throw new RuntimeException("Variable in tall result does not have values: " + variableId);
 
-      variablesMap.put(variableId, (VariableWithValues) var);
+      variablesMap.put(variableId, (VariableWithValues)var);
     }
   }
-  
+
 }

--- a/src/main/java/org/veupathdb/service/eda/ss/model/ResultSetUtils.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/model/ResultSetUtils.java
@@ -3,12 +3,9 @@ package org.veupathdb.service.eda.ss.model;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Optional;
+import java.util.function.Function;
 
 public class ResultSetUtils {
-  public static String getRsStringNotNull(ResultSet rs, String colName) throws SQLException {
-    return Optional.ofNullable(rs.getString(colName)).orElseThrow(
-        () -> new RuntimeException("Found a null for variable column: " + colName));
-  }
 
   public static String getRsStringWithDefault(ResultSet rs, String colName, String defaultVal) throws SQLException {
     return Optional.ofNullable(rs.getString(colName)).orElse(defaultVal);
@@ -19,11 +16,35 @@ public class ResultSetUtils {
     return rs.wasNull() ? defaultVal : val;
   }
 
-  public static Long getIntegerFromString(String value) {
-    return value == null ? null : Long.parseLong(value);
+  public static String getRsString(ResultSet rs, String columnName, boolean requireNonNull) throws SQLException {
+    return getRsString(rs, columnName, requireNonNull, null);
   }
 
-  public static Double getDoubleFromString(String value) {
-    return value == null ? null : Double.parseDouble(value);
+  public static Long getIntegerFromString(ResultSet rs, String columnName, boolean requireNonNull) throws SQLException {
+    return getNumberFromString(rs, columnName, requireNonNull, "integer", val -> Long.parseLong(val));
+  }
+
+  public static Double getDoubleFromString(ResultSet rs, String columnName, boolean requireNonNull) throws SQLException {
+    return getNumberFromString(rs, columnName, requireNonNull, "floating-point", val -> Double.parseDouble(val));
+  }
+
+  private static String getRsString(ResultSet rs, String columnName, boolean requireNonNull, String typeDisplay) throws SQLException {
+    String value = rs.getString(columnName);
+    if (value == null && requireNonNull) {
+      String typeAnnot = typeDisplay == null ? "" : " (" + typeDisplay + ")";
+      throw new RuntimeException("Column " + columnName + " returned a null value but is required" + typeAnnot + ".");
+    }
+    return value;
+  }
+
+  private static <T extends Number> T getNumberFromString(ResultSet rs, String columnName,
+      boolean requireNonNull, String typeDisplay, Function<String,T> converter) throws SQLException {
+    String value = getRsString(rs, columnName, requireNonNull, typeDisplay);
+    try {
+      return value == null ? null : converter.apply(value);
+    }
+    catch (NumberFormatException e) {
+      throw new RuntimeException("Column " + columnName + " returned a value not convertible to " + typeDisplay);
+    }
   }
 }

--- a/src/main/java/org/veupathdb/service/eda/ss/model/filter/StringSetFilter.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/model/filter/StringSetFilter.java
@@ -27,7 +27,7 @@ public class StringSetFilter extends SingleValueFilter<StringVariable> {
   private String createSqlInExpression() {
 
     // validate values against this var's vocabulary
-    /* FIXME: add back at a less risky time, after validating DB data
+    /* FIXME: add back at a less risky time, after validating DB data (ClinEpi Phase 2?)
     List<String> vocab = Optional.ofNullable(_variable.getVocabulary())
         .orElseThrow(() -> new RuntimeException("Var " + _variable.getId() + " has null vocabulary."));
     for (String value : _stringSet) {

--- a/src/main/resources/org/veupathdb/service/eda/ss/stubdb/insertDbData.sql
+++ b/src/main/resources/org/veupathdb/service/eda/ss/stubdb/insertDbData.sql
@@ -46,9 +46,9 @@ insert into Ancestors_ds2324_HshldObsrvtn values ('302', '102');
 insert into AttributeValue_ds2324_HshldObsrvtn values ('302', 'var_ho1', null, 'well', null);
 
 -- participants
--- stable_id, parent_stable_id, provider_label, display_name, definition, ordinal_values, display_type, display_order, display_range_min, display_range_max, range_min, range_max, bin_width_override, bin_width_computed, is_temporal, is_featured, is_merge_key, is_repeated, has_values, data_type, distinct_values_count, is_multi_valued, data_shape, unit, precision
-insert into AttributeGraph_ds2324_Prtcpnt values ('var_p1', null, '_networth', 'Net worth', 'Their net worth', null, 'default', 1, null, null, null, null, null, null, 0, 0, 0, 0, 1, 'number', 10, 0, 'continuous', 'dollars', 2);
-insert into AttributeGraph_ds2324_Prtcpnt values ('var_p2', null, '_shoesize', 'Shoe size', 'Their shoe size', null, 'default', 1, null, null, null, null, null, null, 0, 0, 0, 0, 1, 'number', 10, 0, 'categorical', 'size', 1);
+-- stable_id, parent_stable_id, provider_label, display_name, definition, vocabulary, display_type, display_order, display_range_min, display_range_max, range_min, range_max, bin_width_override, bin_width_computed, is_temporal, is_featured, is_merge_key, is_repeated, has_values, data_type, distinct_values_count, is_multi_valued, data_shape, unit, precision
+insert into AttributeGraph_ds2324_Prtcpnt values ('var_p1', null, '_networth', 'Net worth', 'Their net worth', null, 'default', 1, null, null, '100', '100000', null, '50', 0, 0, 0, 0, 1, 'number', 10, 0, 'continuous', 'dollars', 2);
+insert into AttributeGraph_ds2324_Prtcpnt values ('var_p2', null, '_shoesize', 'Shoe size', 'Their shoe size', null, 'default', 1, null, null, '1.5', '14.5', null, '1', 0, 0, 0, 0, 1, 'number', 10, 0, 'categorical', 'size', 1);
 insert into AttributeGraph_ds2324_Prtcpnt values ('var_p3', null, '_name', 'Name', 'Their name', null, 'default', 1, null, null, null, null, null, null, 0, 0, 0, 0, 1, 'string', 10, 0, 'categorical', null, null);
 insert into AttributeGraph_ds2324_Prtcpnt values ('var_p4', null, '_haircolor', 'Hair color', 'Their hair color', '["blond","brown","silver"]', 'default', 1, null, null, null, null, null, null, 0, 0, 0, 0, 1, 'string', 10, 0, 'categorical', null, null);
 insert into AttributeGraph_ds2324_Prtcpnt values ('var_p5', null, '_earsize', 'Ear size', 'Their ear size', null, 'default', 1, null, null, null, null, null, null, 0, 0, 0, 0,1, 'string', 10, 0,  'categorical', null, null);
@@ -78,11 +78,11 @@ insert into AttributeValue_ds2324_Prtcpnt values ('204', 'var_p4', null, 'silver
 -- intentionally omit var_18 to test left join logic
 
 -- participant observations
--- stable_id, parent_stable_id, provider_label, display_name, definition, ordinal_values, display_type, display_order, display_range_min, display_range_max, range_min, range_max, bin_width_override, bin_width_computed, is_temporal, is_featured, is_merge_key, is_repeated, has_values, data_type, distinct_values_count, is_multi_valued, data_shape, unit, precision
-insert into AttributeGraph_ds2324_PrtcpntObsrvtn values ('var_o1', null, '_weight', 'Weight', 'Their weight', null, 'default', 1, null, null, null, null, null, null, 0, 0, 0, 0, 1, 'number', 10, 0, 'continuous', 'pounds', 2);
-insert into AttributeGraph_ds2324_PrtcpntObsrvtn values ('var_o2', null, '_favnumber', 'Favorite number', 'Their favorite number', null, 'default', 1, null, null, null, null, null, null, 0, 0, 0, 0, 1, 'number', 10, 0, 'categorical', null, null);
-insert into AttributeGraph_ds2324_PrtcpntObsrvtn values ('var_o3', null, '_startdate', 'Start date', 'Their start date', null, 'default', 1, null, null, null, null, null, 'week', 0, 0, 0, 0, 1, 'date', 10, 0, 'continuous', 'date', null);
-insert into AttributeGraph_ds2324_PrtcpntObsrvtn values ('var_o4', null, '_visitdate', 'Visit date', 'Their visit date', null, 'default', 1, null, null, null, null, null, 'week', 0, 0, 0, 0, 1, 'date', 10, 0, 'continuous', 'date', null);
+-- stable_id, parent_stable_id, provider_label, display_name, definition, vocabulary, display_type, display_order, display_range_min, display_range_max, range_min, range_max, bin_width_override, bin_width_computed, is_temporal, is_featured, is_merge_key, is_repeated, has_values, data_type, distinct_values_count, is_multi_valued, data_shape, unit, precision
+insert into AttributeGraph_ds2324_PrtcpntObsrvtn values ('var_o1', null, '_weight', 'Weight', 'Their weight', null, 'default', 1, null, null, '0', '200', null, '5', 0, 0, 0, 0, 1, 'number', 10, 0, 'continuous', 'pounds', 2);
+insert into AttributeGraph_ds2324_PrtcpntObsrvtn values ('var_o2', null, '_favnumber', 'Favorite number', 'Their favorite number', null, 'default', 1, null, null, '0', '1000.123', null, '10', 0, 0, 0, 0, 1, 'number', 10, 0, 'categorical', null, null);
+insert into AttributeGraph_ds2324_PrtcpntObsrvtn values ('var_o3', null, '_startdate', 'Start date', 'Their start date', null, 'default', 1, null, null, to_date('1999','yyyy'), to_date('2010','yyyy'), null, 'week', 0, 0, 0, 0, 1, 'date', 10, 0, 'continuous', 'date', null);
+insert into AttributeGraph_ds2324_PrtcpntObsrvtn values ('var_o4', null, '_visitdate', 'Visit date', 'Their visit date', null, 'default', 1, null, null, to_date('1999','yyyy'), to_date('2010','yyyy'), 'month', 'week', 0, 0, 0, 0, 1, 'date', 10, 0, 'continuous', 'date', null);
 insert into AttributeGraph_ds2324_PrtcpntObsrvtn values ('var_o5', null, '_mood', 'Mood', 'Their mood', null, 'default', 1, null, null, null, null, null, null, 0, 0, 0, 0, 1, 'string', 10, 0, 'categorical', null, null);
 
 -- samples

--- a/src/test/java/org/veupathdb/service/eda/ss/model/EntityResultSetUtilsTest.java
+++ b/src/test/java/org/veupathdb/service/eda/ss/model/EntityResultSetUtilsTest.java
@@ -51,7 +51,7 @@ public class EntityResultSetUtilsTest {
     variablesMap.put(_model.haircolor.getId(), _model.haircolor);
     variablesMap.put(_model.shoesize.getId(), _model.shoesize);
        
-    EntityResultSetUtils.putMultiValuesAsJsonIntoWideRow(multiValues, wideRow, _model.participant, variablesMap);
+    EntityResultSetUtils.putMultiValuesAsJsonIntoWideRow(multiValues, wideRow, variablesMap);
     
     assertEquals("[\"red\",\"blue\"]", wideRow.get(_model.haircolor.getId()));
     assertEquals("[9.5,19]", wideRow.get(_model.shoesize.getId()));


### PR DESCRIPTION
Add checks for required values (with typing where appropriate), which were previously missing.

@d-callan, hopefully once Jay reloads all the studies, this can be merged and 'released' to QA.  Can just hit the

`GET /studies/<studyId>`

endpoint for each study to see if it is compliant.  Will get a 500 if not.