### PR TITLE
Enable file-based subsetting

### DIFF
--- a/src/main/java/org/veupathdb/service/eda/ss/EnvironmentVars.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/EnvironmentVars.java
@@ -25,7 +25,7 @@ public class EnvironmentVars {
     _binaryFilesDirectory = getOptionalVar("BINARY_FILES_DIR", "");
     _binaryFilesMount = getOptionalVar("BINARY_FILES_MOUNT", "");
     _datasetAccessServiceUrl = getRequiredVar("DATASET_ACCESS_SERVICE_URL");
-    _fileBasedSubsettingEnabled = Boolean.parseBoolean(getOptionalVar("FILE_SUBSETTING_ENABLED", "false"));
+    _fileBasedSubsettingEnabled = Boolean.parseBoolean(getOptionalVar("FILE_SUBSETTING_ENABLED", "true"));
   }
 
   public boolean isDevelopmentMode() {


### PR DESCRIPTION
## Overview
Currently, file-based subsetting is only enabled in dev and feat.

The files are not yet being produced by the workflow (blocked by https://redmine.apidb.org/issues/51385). However, this change will only use the files if they're present, falling back to Oracle if not.

The plan is to manually deploy the files for only the megastudy (and any other studies large enough that the files are determined necessary) and allow the files to be conditionally used in QA and prod.