### PR TITLE
Filter awareness in per-root-entity-vocab endpoint

### DIFF
--- a/api.raml
+++ b/api.raml
@@ -108,7 +108,7 @@ securitySchemes:
             /root-vocab:
               description: |
                 Groups values of this variable by their rows' root entity ID (collecting a vocabulary of values specific
-                to each root entityq record) and returns them as a tabular result where each row is a distinct 
+                to each root entity record) and returns them as a tabular result where each row is a distinct 
                 combination of root entity ID and variable value. This is useful for reducing applicable vocabularies 
                 of this variable to only the root entities remaining after a subset operation.
               post:

--- a/api.raml
+++ b/api.raml
@@ -108,11 +108,14 @@ securitySchemes:
             /root-vocab:
               description: |
                 Groups values of this variable by their rows' root entity ID (collecting a vocabulary of values specific
-                to each root entity record) and returns them as a tabular result where each row is a distinct 
+                to each root entityq record) and returns them as a tabular result where each row is a distinct 
                 combination of root entity ID and variable value. This is useful for reducing applicable vocabularies 
                 of this variable to only the root entities remaining after a subset operation.
-              get:
+              post:
                 securedBy: header-auth
+                body:
+                  application/json:
+                    type: lib.VocabByRootEntityPostRequest
                 responses:
                   200:
                     body:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import java.net.URL
 
 plugins {
   java
-  id("org.veupathdb.lib.gradle.container.container-utils") version "4.8.9"
+  id("org.veupathdb.lib.gradle.container.container-utils") version "4.8.5"
   id("com.github.johnrengelman.shadow") version "7.1.2"
 }
 
@@ -87,8 +87,8 @@ repositories {
 
 // versions
 val coreLib       = "6.15.3"        // Container core lib version
-val edaCommon     = "10.7.1"        // EDA Common version
-val libSubsetting = "4.7.1"         // lib-eda-subsetting version
+val edaCommon     = "10.8.0"        // EDA Common version
+val libSubsetting = "4.8.0"         // lib-eda-subsetting version
 val fgputil       = "2.12.9-jakarta" // FgpUtil version
 
 // use local EdaCommon compiled schema if project exists, else use released version;

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import java.net.URL
 
 plugins {
   java
-  id("org.veupathdb.lib.gradle.container.container-utils") version "4.8.5"
+  id("org.veupathdb.lib.gradle.container.container-utils") version "4.8.9"
   id("com.github.johnrengelman.shadow") version "7.1.2"
 }
 

--- a/schema/library.raml
+++ b/schema/library.raml
@@ -240,6 +240,11 @@ types:
       filters: API_Filter[]
       binSpec?: BinSpecWithRange
       valueSpec: ValueSpec
+  VocabByRootEntityPostRequest:
+    type: object
+    additionalProperties: false
+    properties:
+      filters: API_Filter[]
   VocabByRootEntityPostResponse:
     type: EntityTabularPostResponse
     additionalProperties: false

--- a/src/main/java/org/veupathdb/service/eda/ss/service/ApiConversionUtil.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/service/ApiConversionUtil.java
@@ -1,17 +1,24 @@
 package org.veupathdb.service.eda.ss.service;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.InternalServerErrorException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.gusdb.fgputil.FormatUtil;
 import org.gusdb.fgputil.SortDirection;
 import org.gusdb.fgputil.functional.TreeNode;
 import org.veupathdb.service.eda.common.client.DatasetAccessClient.StudyDatasetInfo;
 import org.veupathdb.service.eda.generated.model.*;
+import org.veupathdb.service.eda.ss.Utils;
 import org.veupathdb.service.eda.ss.model.Entity;
 import org.veupathdb.service.eda.ss.model.Study;
 import org.veupathdb.service.eda.ss.model.StudyOverview;
@@ -20,6 +27,15 @@ import org.veupathdb.service.eda.ss.model.distribution.BinUnits;
 import org.veupathdb.service.eda.ss.model.distribution.DateDistributionConfig;
 import org.veupathdb.service.eda.ss.model.distribution.NumberDistributionConfig;
 import org.veupathdb.service.eda.ss.model.distribution.ValueSpec;
+import org.veupathdb.service.eda.ss.model.filter.DateRangeFilter;
+import org.veupathdb.service.eda.ss.model.filter.DateSetFilter;
+import org.veupathdb.service.eda.ss.model.filter.Filter;
+import org.veupathdb.service.eda.ss.model.filter.LongitudeRangeFilter;
+import org.veupathdb.service.eda.ss.model.filter.MultiFilter;
+import org.veupathdb.service.eda.ss.model.filter.MultiFilterSubFilter;
+import org.veupathdb.service.eda.ss.model.filter.NumberRangeFilter;
+import org.veupathdb.service.eda.ss.model.filter.NumberSetFilter;
+import org.veupathdb.service.eda.ss.model.filter.StringSetFilter;
 import org.veupathdb.service.eda.ss.model.tabular.TabularHeaderFormat;
 import org.veupathdb.service.eda.ss.model.varcollection.DateVarCollection;
 import org.veupathdb.service.eda.ss.model.varcollection.FloatingPointVarCollection;
@@ -33,6 +49,7 @@ import org.veupathdb.service.eda.ss.model.variable.LongitudeVariable;
 import org.veupathdb.service.eda.ss.model.variable.StringVariable;
 import org.veupathdb.service.eda.ss.model.variable.Variable;
 import org.veupathdb.service.eda.ss.model.variable.VariableDataShape;
+import org.veupathdb.service.eda.ss.model.variable.VariableDisplayType;
 import org.veupathdb.service.eda.ss.model.variable.VariableWithValues;
 
 public class ApiConversionUtil {
@@ -317,4 +334,154 @@ public class ApiConversionUtil {
         }).collect(Collectors.toList());
   }
 
+  /*
+   * Given a study and a set of API filters, construct and return a set of filters, each being the appropriate
+   * filter subclass
+   */
+  public static List<Filter> toInternalFilters(Study study, List<APIFilter> filters, String appDbSchema) {
+    List<Filter> subsetFilters = new ArrayList<>();
+
+    // FIXME: need this until we turn on schema-level checking to enforce requiredness
+    if (filters == null) return subsetFilters;
+
+    String errPrfx = "A filter references an unfound ";
+
+    for (APIFilter apiFilter : filters) {
+
+      // validate filter's entity id
+      Supplier<BadRequestException> excep =
+          () -> new BadRequestException(errPrfx + "entity ID: " + apiFilter.getEntityId());
+      Entity entity = study.getEntity(apiFilter.getEntityId()).orElseThrow(excep);
+
+      Filter newFilter;
+      if (apiFilter instanceof APIDateRangeFilter) {
+        newFilter = unpackDateRangeFilter(apiFilter, entity, appDbSchema);
+      }
+      else if (apiFilter instanceof APIDateSetFilter) {
+        newFilter = unpackDateSetFilter(apiFilter, entity, appDbSchema);
+      }
+      else if (apiFilter instanceof APINumberRangeFilter) {
+        newFilter = unpackNumberRangeFilter(apiFilter, entity, appDbSchema);
+      }
+      else if (apiFilter instanceof APINumberSetFilter) {
+        newFilter = unpackNumberSetFilter(apiFilter, entity, appDbSchema);
+      }
+      else if (apiFilter instanceof APILongitudeRangeFilter) {
+        newFilter = unpackLongitudeRangeFilter(apiFilter, entity, appDbSchema);
+      }
+      else if (apiFilter instanceof APIStringSetFilter) {
+        newFilter = unpackStringSetFilter(apiFilter, entity, appDbSchema);
+      }
+      else if (apiFilter instanceof APIMultiFilter) {
+        newFilter = unpackMultiFilter(apiFilter, entity, appDbSchema);
+      }
+      else
+        throw new InternalServerErrorException("Input filter not an expected subclass of Filter");
+
+      subsetFilters.add(newFilter);
+    }
+    return subsetFilters;
+  }
+
+  private static DateRangeFilter unpackDateRangeFilter(APIFilter apiFilter, Entity entity, String appDbSchema) {
+    APIDateRangeFilter f = (APIDateRangeFilter)apiFilter;
+    if (f.getMin() == null) throw new BadRequestException("Date range filter: min is a required property");
+    if (f.getMax() == null) throw new BadRequestException("Date range filter: max is a required property");
+    DateVariable var = DateVariable.assertType(entity.getVariableOrThrow(f.getVariableId()));
+    return new DateRangeFilter(appDbSchema, entity, var,
+        FormatUtil.parseDateTime(Utils.standardizeLocalDateTime(f.getMin())),
+        FormatUtil.parseDateTime(Utils.standardizeLocalDateTime(f.getMax())));
+  }
+
+  private static DateSetFilter unpackDateSetFilter(APIFilter apiFilter, Entity entity, String appDbSchema) {
+    APIDateSetFilter f = (APIDateSetFilter)apiFilter;
+    if (f.getDateSet() == null || f.getDateSet().isEmpty())
+      throw new BadRequestException(("Date set filter: >0 dates must be specified"));
+    DateVariable var = DateVariable.assertType(entity.getVariableOrThrow(f.getVariableId()));
+    List<LocalDateTime> dateSet = new ArrayList<>();
+    for (String dateStr : f.getDateSet()) {
+      dateSet.add(FormatUtil.parseDateTime(Utils.standardizeLocalDateTime(dateStr)));
+    }
+    return new DateSetFilter(appDbSchema, entity, var, dateSet);
+  }
+
+  private static NumberRangeFilter<?> unpackNumberRangeFilter(APIFilter apiFilter, Entity entity, String appDbSchema) {
+    APINumberRangeFilter f = (APINumberRangeFilter)apiFilter;
+    if (f.getMin() == null) throw new BadRequestException("Number range filter: min is a required property");
+    if (f.getMax() == null) throw new BadRequestException("Number range filter: max is a required property");
+
+    Variable var = entity.getVariableOrThrow(f.getVariableId());
+
+    // need to check for each number variable type
+    Optional<NumberRangeFilter<Long>> intFilter = IntegerVariable.assertType(var)
+        .map(intVar -> new NumberRangeFilter<>(appDbSchema, entity, intVar, f.getMin(), f.getMax()));
+    if (intFilter.isPresent()) return intFilter.get();
+
+    // not integer var; try floating point or else throw
+    return FloatingPointVariable.assertType(var)
+        .map(floatVar -> new NumberRangeFilter<>(appDbSchema, entity, floatVar, f.getMin(), f.getMax()))
+        .orElseThrow(() -> new BadRequestException("Variable " + var.getId() +
+            " of entity " + var.getEntityId() + " is not a number or integer variable."));
+  }
+
+  private static NumberSetFilter<?> unpackNumberSetFilter(APIFilter apiFilter, Entity entity, String appDbSchema) {
+    APINumberSetFilter f = (APINumberSetFilter)apiFilter;
+    if (f.getNumberSet() == null || f.getNumberSet().isEmpty())
+      throw new BadRequestException(("Number set filter: >0 numbers must be specified"));
+
+    Variable var = entity.getVariableOrThrow(f.getVariableId());
+
+    // need to check for each number variable type
+    Optional<NumberSetFilter<Long>> intFilter = IntegerVariable.assertType(var)
+        .map(intVar -> new NumberSetFilter<>(appDbSchema, entity, intVar, f.getNumberSet()));
+    if (intFilter.isPresent()) return intFilter.get();
+
+    // not integer var; try floating point or else throw
+    return FloatingPointVariable.assertType(var)
+        .map(floatVar -> new NumberSetFilter<>(appDbSchema, entity, floatVar, f.getNumberSet()))
+        .orElseThrow(() -> new BadRequestException("Variable " + var.getId() +
+            " of entity " + var.getEntityId() + " is not a number or integer variable."));
+  }
+
+  private static LongitudeRangeFilter unpackLongitudeRangeFilter(APIFilter apiFilter, Entity entity, String appDbSchema) {
+    APILongitudeRangeFilter f = (APILongitudeRangeFilter)apiFilter;
+    if (f.getLeft() == null) throw new BadRequestException("Longitude range filter: left is a required property");
+    if (f.getRight() == null) throw new BadRequestException("Longitude range filter: right is a required property");
+    LongitudeVariable var = LongitudeVariable.assertType(entity.getVariableOrThrow(f.getVariableId()));
+    return new LongitudeRangeFilter(appDbSchema, entity, var, f.getLeft(), f.getRight());
+  }
+
+  private static StringSetFilter unpackStringSetFilter(APIFilter apiFilter, Entity entity, String appDbSchema) {
+    APIStringSetFilter f = (APIStringSetFilter)apiFilter;
+    if (f.getStringSet() == null || f.getStringSet().isEmpty())
+      throw new BadRequestException(("String set filter: >0 strings must be specified"));
+    StringVariable stringVar = StringVariable.assertType(entity.getVariableOrThrow(f.getVariableId()));
+    return new StringSetFilter(appDbSchema, entity, stringVar, f.getStringSet());
+  }
+
+  private static MultiFilter unpackMultiFilter(APIFilter apiFilter, Entity entity, String appDbSchema) {
+    APIMultiFilter f = (APIMultiFilter)apiFilter;
+    if (f.getSubFilters().isEmpty())
+      throw new BadRequestException("Multifilter may not have an empty list of subFilters");
+
+    // validate multifilter variable
+    String mfVarId = f.getVariableId();
+    Variable multiFilterVariable = entity.getVariable(mfVarId).orElseThrow(() ->
+        new BadRequestException("Multifilter includes invalid multifilter variable ID: " + mfVarId));
+    if (multiFilterVariable.getDisplayType() != VariableDisplayType.MULTIFILTER)
+      throw new BadRequestException("Multifilter variable does not have display type 'multifilter': " + mfVarId);
+
+    // validate subfilters
+    List<MultiFilterSubFilter> subFilters = new ArrayList<>();
+    for (APIMultiFilterSubFilter apiSubFilter : f.getSubFilters()) {
+      String variableId = apiSubFilter.getVariableId();
+      if (!entity.getMultiFilterMap().get(mfVarId).contains(variableId))
+        throw new BadRequestException("Multifilter includes subfilter with invalid variable: " + variableId);
+      Variable var = entity.getVariable(variableId).orElseThrow(() -> new BadRequestException("Multifilter includes invalid variable ID: " + variableId));
+      StringVariable subFilterVar = StringVariable.assertType(var);
+      subFilters.add(new MultiFilterSubFilter(subFilterVar, apiSubFilter.getStringSet()));
+    }
+
+    return new MultiFilter(appDbSchema, entity, subFilters, MultiFilter.MultiFilterOperation.fromString(f.getOperation().getValue()));
+  }
 }

--- a/src/main/java/org/veupathdb/service/eda/ss/service/RequestBundle.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/service/RequestBundle.java
@@ -1,44 +1,22 @@
 package org.veupathdb.service.eda.ss.service;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotFoundException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.gusdb.fgputil.FormatUtil;
-import org.veupathdb.service.eda.generated.model.APIDateRangeFilter;
-import org.veupathdb.service.eda.generated.model.APIDateSetFilter;
 import org.veupathdb.service.eda.generated.model.APIFilter;
-import org.veupathdb.service.eda.generated.model.APILongitudeRangeFilter;
-import org.veupathdb.service.eda.generated.model.APIMultiFilter;
-import org.veupathdb.service.eda.generated.model.APIMultiFilterSubFilter;
-import org.veupathdb.service.eda.generated.model.APINumberRangeFilter;
-import org.veupathdb.service.eda.generated.model.APINumberSetFilter;
-import org.veupathdb.service.eda.generated.model.APIStringSetFilter;
 import org.veupathdb.service.eda.generated.model.APITabularReportConfig;
 import org.veupathdb.service.eda.generated.model.SortSpecEntry;
-import org.veupathdb.service.eda.ss.Utils;
 import org.veupathdb.service.eda.ss.model.Entity;
 import org.veupathdb.service.eda.ss.model.Study;
 import org.veupathdb.service.eda.ss.model.tabular.TabularReportConfig;
 import org.veupathdb.service.eda.ss.model.variable.*;
-import org.veupathdb.service.eda.ss.model.filter.DateRangeFilter;
-import org.veupathdb.service.eda.ss.model.filter.DateSetFilter;
 import org.veupathdb.service.eda.ss.model.filter.Filter;
-import org.veupathdb.service.eda.ss.model.filter.LongitudeRangeFilter;
-import org.veupathdb.service.eda.ss.model.filter.MultiFilter;
-import org.veupathdb.service.eda.ss.model.filter.MultiFilter.MultiFilterOperation;
-import org.veupathdb.service.eda.ss.model.filter.MultiFilterSubFilter;
-import org.veupathdb.service.eda.ss.model.filter.NumberRangeFilter;
-import org.veupathdb.service.eda.ss.model.filter.NumberSetFilter;
-import org.veupathdb.service.eda.ss.model.filter.StringSetFilter;
 
 public class RequestBundle {
 
@@ -50,7 +28,7 @@ public class RequestBundle {
 
     List<VariableWithValues> variables = getEntityVariables(entity, variableIds);
 
-    List<Filter> filters = constructFiltersFromAPIFilters(study, apiFilters, dataSchema);
+    List<Filter> filters = ApiConversionUtil.toInternalFilters(study, apiFilters, dataSchema);
 
     TabularReportConfig reportConfig = getTabularReportConfig(entity, Optional.ofNullable(apiReportConfig));
 
@@ -127,157 +105,6 @@ public class RequestBundle {
     return variables.stream()
         .map(var -> (VariableWithValues) var)
         .collect(Collectors.toList());
-  }
-
-  /*
-   * Given a study and a set of API filters, construct and return a set of filters, each being the appropriate
-   * filter subclass
-   */
-  static List<Filter> constructFiltersFromAPIFilters(Study study, List<APIFilter> filters, String appDbSchema) {
-    List<Filter> subsetFilters = new ArrayList<>();
-
-    // FIXME: need this until we turn on schema-level checking to enforce requiredness
-    if (filters == null) return subsetFilters;
-
-    String errPrfx = "A filter references an unfound ";
-
-    for (APIFilter apiFilter : filters) {
-
-      // validate filter's entity id
-      Supplier<BadRequestException> excep =
-          () -> new BadRequestException(errPrfx + "entity ID: " + apiFilter.getEntityId());
-      Entity entity = study.getEntity(apiFilter.getEntityId()).orElseThrow(excep);
-
-      Filter newFilter;
-      if (apiFilter instanceof APIDateRangeFilter) {
-        newFilter = unpackDateRangeFilter(apiFilter, entity, appDbSchema);
-      }
-      else if (apiFilter instanceof APIDateSetFilter) {
-        newFilter = unpackDateSetFilter(apiFilter, entity, appDbSchema);
-      }
-      else if (apiFilter instanceof APINumberRangeFilter) {
-        newFilter = unpackNumberRangeFilter(apiFilter, entity, appDbSchema);
-      }
-      else if (apiFilter instanceof APINumberSetFilter) {
-        newFilter = unpackNumberSetFilter(apiFilter, entity, appDbSchema);
-      }
-      else if (apiFilter instanceof APILongitudeRangeFilter) {
-        newFilter = unpackLongitudeRangeFilter(apiFilter, entity, appDbSchema);
-      }
-      else if (apiFilter instanceof APIStringSetFilter) {
-        newFilter = unpackStringSetFilter(apiFilter, entity, appDbSchema);
-      }
-      else if (apiFilter instanceof APIMultiFilter) {
-        newFilter = unpackMultiFilter(apiFilter, entity, appDbSchema);
-      }
-      else
-        throw new InternalServerErrorException("Input filter not an expected subclass of Filter");
-
-      subsetFilters.add(newFilter);
-    }
-    return subsetFilters;
-  }
-
-  private static DateRangeFilter unpackDateRangeFilter(APIFilter apiFilter, Entity entity, String appDbSchema) {
-    APIDateRangeFilter f = (APIDateRangeFilter)apiFilter;
-    if (f.getMin() == null) throw new BadRequestException("Date range filter: min is a required property");
-    if (f.getMax() == null) throw new BadRequestException("Date range filter: max is a required property");
-    DateVariable var = DateVariable.assertType(entity.getVariableOrThrow(f.getVariableId()));
-    return new DateRangeFilter(appDbSchema, entity, var,
-        FormatUtil.parseDateTime(Utils.standardizeLocalDateTime(f.getMin())),
-        FormatUtil.parseDateTime(Utils.standardizeLocalDateTime(f.getMax())));
-  }
-
-  private static DateSetFilter unpackDateSetFilter(APIFilter apiFilter, Entity entity, String appDbSchema) {
-    APIDateSetFilter f = (APIDateSetFilter)apiFilter;
-    if (f.getDateSet() == null || f.getDateSet().isEmpty())
-      throw new BadRequestException(("Date set filter: >0 dates must be specified"));
-    DateVariable var = DateVariable.assertType(entity.getVariableOrThrow(f.getVariableId()));
-    List<LocalDateTime> dateSet = new ArrayList<>();
-    for (String dateStr : f.getDateSet()) {
-      dateSet.add(FormatUtil.parseDateTime(Utils.standardizeLocalDateTime(dateStr)));
-    }
-    return new DateSetFilter(appDbSchema, entity, var, dateSet);
-  }
-
-  private static NumberRangeFilter<?> unpackNumberRangeFilter(APIFilter apiFilter, Entity entity, String appDbSchema) {
-    APINumberRangeFilter f = (APINumberRangeFilter)apiFilter;
-    if (f.getMin() == null) throw new BadRequestException("Number range filter: min is a required property");
-    if (f.getMax() == null) throw new BadRequestException("Number range filter: max is a required property");
-
-    Variable var = entity.getVariableOrThrow(f.getVariableId());
-
-    // need to check for each number variable type
-    Optional<NumberRangeFilter<Long>> intFilter = IntegerVariable.assertType(var)
-        .map(intVar -> new NumberRangeFilter<>(appDbSchema, entity, intVar, f.getMin(), f.getMax()));
-    if (intFilter.isPresent()) return intFilter.get();
-
-    // not integer var; try floating point or else throw
-    return FloatingPointVariable.assertType(var)
-        .map(floatVar -> new NumberRangeFilter<>(appDbSchema, entity, floatVar, f.getMin(), f.getMax()))
-        .orElseThrow(() -> new BadRequestException("Variable " + var.getId() +
-            " of entity " + var.getEntityId() + " is not a number or integer variable."));
-  }
-
-  private static NumberSetFilter<?> unpackNumberSetFilter(APIFilter apiFilter, Entity entity, String appDbSchema) {
-    APINumberSetFilter f = (APINumberSetFilter)apiFilter;
-    if (f.getNumberSet() == null || f.getNumberSet().isEmpty())
-      throw new BadRequestException(("Number set filter: >0 numbers must be specified"));
-
-    Variable var = entity.getVariableOrThrow(f.getVariableId());
-
-    // need to check for each number variable type
-    Optional<NumberSetFilter<Long>> intFilter = IntegerVariable.assertType(var)
-        .map(intVar -> new NumberSetFilter<>(appDbSchema, entity, intVar, f.getNumberSet()));
-    if (intFilter.isPresent()) return intFilter.get();
-
-    // not integer var; try floating point or else throw
-    return FloatingPointVariable.assertType(var)
-        .map(floatVar -> new NumberSetFilter<>(appDbSchema, entity, floatVar, f.getNumberSet()))
-        .orElseThrow(() -> new BadRequestException("Variable " + var.getId() +
-            " of entity " + var.getEntityId() + " is not a number or integer variable."));
-  }
-
-  private static LongitudeRangeFilter unpackLongitudeRangeFilter(APIFilter apiFilter, Entity entity, String appDbSchema) {
-    APILongitudeRangeFilter f = (APILongitudeRangeFilter)apiFilter;
-    if (f.getLeft() == null) throw new BadRequestException("Longitude range filter: left is a required property");
-    if (f.getRight() == null) throw new BadRequestException("Longitude range filter: right is a required property");
-    LongitudeVariable var = LongitudeVariable.assertType(entity.getVariableOrThrow(f.getVariableId()));
-    return new LongitudeRangeFilter(appDbSchema, entity, var, f.getLeft(), f.getRight());
-  }
-
-  private static StringSetFilter unpackStringSetFilter(APIFilter apiFilter, Entity entity, String appDbSchema) {
-    APIStringSetFilter f = (APIStringSetFilter)apiFilter;
-    if (f.getStringSet() == null || f.getStringSet().isEmpty())
-      throw new BadRequestException(("String set filter: >0 strings must be specified"));
-    StringVariable stringVar = StringVariable.assertType(entity.getVariableOrThrow(f.getVariableId()));
-    return new StringSetFilter(appDbSchema, entity, stringVar, f.getStringSet());
-  }
-
-  private static MultiFilter unpackMultiFilter(APIFilter apiFilter, Entity entity, String appDbSchema) {
-    APIMultiFilter f = (APIMultiFilter)apiFilter;
-    if (f.getSubFilters().isEmpty())
-      throw new BadRequestException("Multifilter may not have an empty list of subFilters");
-
-    // validate multifilter variable
-    String mfVarId = f.getVariableId();
-    Variable multiFilterVariable = entity.getVariable(mfVarId).orElseThrow(() ->
-        new BadRequestException("Multifilter includes invalid multifilter variable ID: " + mfVarId));
-    if (multiFilterVariable.getDisplayType() != VariableDisplayType.MULTIFILTER)
-      throw new BadRequestException("Multifilter variable does not have display type 'multifilter': " + mfVarId);
-
-    // validate subfilters
-    List<MultiFilterSubFilter> subFilters = new ArrayList<>();
-    for (APIMultiFilterSubFilter apiSubFilter : f.getSubFilters()) {
-      String variableId = apiSubFilter.getVariableId();
-      if (!entity.getMultiFilterMap().get(mfVarId).contains(variableId))
-        throw new BadRequestException("Multifilter includes subfilter with invalid variable: " + variableId);
-      Variable var = entity.getVariable(variableId).orElseThrow(() -> new BadRequestException("Multifilter includes invalid variable ID: " + variableId));
-      StringVariable subFilterVar = StringVariable.assertType(var);
-      subFilters.add(new MultiFilterSubFilter(subFilterVar, apiSubFilter.getStringSet()));
-    }
-
-    return new MultiFilter(appDbSchema, entity, subFilters, MultiFilterOperation.fromString(f.getOperation().getValue()));
   }
 
   private final Study _study;

--- a/src/main/java/org/veupathdb/service/eda/ss/service/StudiesService.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/service/StudiesService.java
@@ -35,7 +35,6 @@ import org.veupathdb.service.eda.common.client.DatasetAccessClient;
 import org.veupathdb.service.eda.common.client.DatasetAccessClient.StudyDatasetInfo;
 import org.veupathdb.service.eda.generated.model.APIEntity;
 import org.veupathdb.service.eda.generated.model.APIStudyDetail;
-import org.veupathdb.service.eda.generated.model.APIVariableDataShape;
 import org.veupathdb.service.eda.generated.model.EntityCountPostRequest;
 import org.veupathdb.service.eda.generated.model.EntityCountPostResponse;
 import org.veupathdb.service.eda.generated.model.EntityCountPostResponseImpl;
@@ -51,6 +50,7 @@ import org.veupathdb.service.eda.generated.model.ValueSpec;
 import org.veupathdb.service.eda.generated.model.VariableDistributionPostRequest;
 import org.veupathdb.service.eda.generated.model.VariableDistributionPostResponse;
 import org.veupathdb.service.eda.generated.model.VariableDistributionPostResponseImpl;
+import org.veupathdb.service.eda.generated.model.VocabByRootEntityPostRequest;
 import org.veupathdb.service.eda.generated.model.VocabByRootEntityPostResponseStream;
 import org.veupathdb.service.eda.generated.resources.Studies;
 import org.veupathdb.service.eda.ss.Resources;
@@ -210,10 +210,11 @@ public class StudiesService implements Studies {
   }
 
   @Override
-  public GetStudiesEntitiesVariablesRootVocabByStudyIdAndEntityIdAndVariableIdResponse getStudiesEntitiesVariablesRootVocabByStudyIdAndEntityIdAndVariableId(String studyId, String entityId, String variableId) {
+  public PostStudiesEntitiesVariablesRootVocabByStudyIdAndEntityIdAndVariableIdResponse postStudiesEntitiesVariablesRootVocabByStudyIdAndEntityIdAndVariableId(String studyId, String entityId, String variableId, VocabByRootEntityPostRequest body) {
     checkPerms(_request, studyId, StudyAccess::allowSubsetting);
     Study study = getStudyResolver().getStudyById(studyId);
     String dataSchema = resolveSchema(study);
+
 
     // Validate entity/variable ID existence
     Variable var = study.getEntity(entityId)
@@ -242,7 +243,8 @@ public class StudiesService implements Studies {
           Resources.getApplicationDataSource(),
           study.getEntityTree().getContents(),
           variableWithValues,
-          resultConsumer);
+          resultConsumer,
+          toInternalFilters(study, body.getFilters(), dataSchema));
 
       try {
         bufferedWriter.flush();
@@ -251,7 +253,7 @@ public class StudiesService implements Studies {
       }
     });
 
-    return GetStudiesEntitiesVariablesRootVocabByStudyIdAndEntityIdAndVariableIdResponse.respond200WithTextTabSeparatedValues(streamer);
+    return PostStudiesEntitiesVariablesRootVocabByStudyIdAndEntityIdAndVariableIdResponse.respond200WithTextTabSeparatedValues(streamer);
   }
 
   public static <T> T handleTabularRequest(

--- a/src/test/java/org/veupathdb/service/eda/ss/service/StudiesTest.java
+++ b/src/test/java/org/veupathdb/service/eda/ss/service/StudiesTest.java
@@ -81,7 +81,7 @@ public class StudiesTest {
     numberFilter.setMax(10);
     afs.add(numberFilter);
     
-    RequestBundle.constructFiltersFromAPIFilters(_model.study, afs, StubDb.APP_DB_SCHEMA);
+    ApiConversionUtil.toInternalFilters(_model.study, afs, StubDb.APP_DB_SCHEMA);
     
     assertEquals(2, afs.size());
   }
@@ -105,7 +105,7 @@ public class StudiesTest {
       nakedFilter.setEntityId(_model.observation.getId());
       afs.add(nakedFilter);
 
-      RequestBundle.constructFiltersFromAPIFilters(_model.study, afs, StubDb.APP_DB_SCHEMA);
+      ApiConversionUtil.toInternalFilters(_model.study, afs, StubDb.APP_DB_SCHEMA);
     });
   }
 


### PR DESCRIPTION
## Overview
* Moved to `id("org.veupathdb.lib.gradle.container.container-utils") version "4.8.5"` for now. I think the upgrade is waiting on the derived var changes in EdaCommon to be releasable but I could be wrong. I can't get it to build without upgrading everywhere.

* Moved method to convert filters from `RequestBundle` to `ApiConversionUtil` for re-use.