### PR TITLE
Use relational subsetting when sorting required

### DIFF
--- a/src/main/java/org/veupathdb/service/eda/ss/service/StudiesService.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/service/StudiesService.java
@@ -328,6 +328,10 @@ public class StudiesService implements Studies {
     LOG.debug("Determining whether to use file-based subsetting in request for study '" +
         requestBundle.getStudy().getStudyId() + "', entity '" + requestBundle.getTargetEntity() + "'.");
 
+    if (requestBundle.getReportConfig().requiresSorting()) {
+      return false;
+    }
+
     if (requestBundle.getReportConfig().getDataSourceType() == DataSourceType.DATABASE) {
       LOG.debug("Can't use files because: client request specified data source to be DATABASE");
       return false;


### PR DESCRIPTION
Resolves https://github.com/VEuPathDB/EdaSubsettingService/issues/128

Don't use file-based subsetting when sorting or pagination is required.